### PR TITLE
Add DynamoDB storage driver

### DIFF
--- a/docs/user/usage.rst
+++ b/docs/user/usage.rst
@@ -136,11 +136,11 @@ Out of the box, Slack Machine provides 2 options for storage backend:
   *Class*: ``machine.storage.backends.redis.RedisStorage``
 
 - **HBase**: this backend stores data in `HBase`_. HBase is a columnar store. This backend is for
-advanced users only. You should only use it if you already have a HBase cluster running and cannot
-use Redis for some reason. This backend requires 2 variables to be set in your ``local_settings.py``:
-``HBASE_URL`` and ``HBASE_TABLE``.
+  advanced users only. You should only use it if you already have a HBase cluster running and cannot
+  use Redis for some reason. This backend requires 2 variables to be set in your ``local_settings.py``:
+  ``HBASE_URL`` and ``HBASE_TABLE``.
 
-   *Class*: ``machine.storage.backends.hbase.HBaseStorage``
+  *Class*: ``machine.storage.backends.hbase.HBaseStorage``
     
 - **DynamoDB**: this backend stores data in `DynamoDB`. DynamoDB is a managed NoSQL datastore on 
   AWS that, among other things, allows for easy persistance of objects by key. The DynamoDB backend

--- a/docs/user/usage.rst
+++ b/docs/user/usage.rst
@@ -140,7 +140,25 @@ advanced users only. You should only use it if you already have a HBase cluster 
 use Redis for some reason. This backend requires 2 variables to be set in your ``local_settings.py``:
 ``HBASE_URL`` and ``HBASE_TABLE``.
 
-    *Class*: ``machine.storage.backends.hbase.HBaseStorage``
+   *Class*: ``machine.storage.backends.hbase.HBaseStorage``
+    
+- **DynamoDB**: this backend stores data in `DynamoDB`. DynamoDB is a managed NoSQL datastore on 
+  AWS that, among other things, allows for easy persistance of objects by key. The DynamoDB backend
+  requires either a set of valid AWS account credentials, or a locally running DynamoDB test bed, 
+  such as the one included in [localstack](https://github.com/localstack/localstack). This backend
+  requires only the environment variables or path-based AWS credentials that are normally used to
+  access AWS endpoints. The following are optional parameters that can be set in your ``local_settings.py``
+  or `SM_` environment variable slack-machine settings:
+  
+  Optional parameters:
+  
+  - ``DYNAMODB_ENDPOINT_URL``: specifies an optional alternate endpoint, for local bot testing
+  - ``DYNAMODB_KEY_PREFIX``: an optional prefix to use within the key lookup. Defaults to `SM:`
+  - ``DYNAMODB_TABLE_NAME``: specifies the table to use in DynamoDB. Defaults to `slack-machine-state`
+  - ``DYNAMODB_CREATE_TABLE``: optionally -create- the table to be used in DynamoDB. Defaults to `False`
+  - ``DYNAMODB_CLIENT``: if custom configuration is needed for the DynamoDB client, an optional [boto3](https://aws.amazon.com/sdk-for-python/) client can be specified here
+  
+  *Class*: ``machine.storage.backends.dynamodb.DynamoDBStorage``
 
 So if, for example, you want to configure Slack Machine to use Redis as a storage backend, with your Redis
 instance running on *localhost* on the default port, you would add this to your ``local_settings.py``:
@@ -153,5 +171,7 @@ instance running on *localhost* on the default port, you would add this to your 
 .. _Redis: https://redis.io/
 
 .. _HBase: https://hbase.apache.org/
+
+.. DynamoDB: https://aws.amazon.com/dynamodb/
 
 That's all there is to it!

--- a/docs/user/usage.rst
+++ b/docs/user/usage.rst
@@ -142,10 +142,10 @@ Out of the box, Slack Machine provides 2 options for storage backend:
 
   *Class*: ``machine.storage.backends.hbase.HBaseStorage``
     
-- **DynamoDB**: this backend stores data in `DynamoDB`. DynamoDB is a managed NoSQL datastore on 
+- **DynamoDB**: this backend stores data in `DynamoDB`. `DynamoDB`_ is a managed NoSQL datastore on 
   AWS that, among other things, allows for easy persistance of objects by key. The DynamoDB backend
   requires either a set of valid AWS account credentials, or a locally running DynamoDB test bed, 
-  such as the one included in [localstack](https://github.com/localstack/localstack). This backend
+  such as the one included in `localstack`_. This backend
   requires only the environment variables or path-based AWS credentials that are normally used to
   access AWS endpoints. The following are optional parameters that can be set in your ``local_settings.py``
   or `SM_` environment variable slack-machine settings:
@@ -156,7 +156,7 @@ Out of the box, Slack Machine provides 2 options for storage backend:
   - ``DYNAMODB_KEY_PREFIX``: an optional prefix to use within the key lookup. Defaults to `SM:`
   - ``DYNAMODB_TABLE_NAME``: specifies the table to use in DynamoDB. Defaults to `slack-machine-state`
   - ``DYNAMODB_CREATE_TABLE``: optionally -create- the table to be used in DynamoDB. Defaults to `False`
-  - ``DYNAMODB_CLIENT``: if custom configuration is needed for the DynamoDB client, an optional [boto3](https://aws.amazon.com/sdk-for-python) client can be specified here
+  - ``DYNAMODB_CLIENT``: if custom configuration is needed for the DynamoDB client, an optional `boto3`_ client can be specified here
   
   *Class*: ``machine.storage.backends.dynamodb.DynamoDBStorage``
 
@@ -172,6 +172,10 @@ instance running on *localhost* on the default port, you would add this to your 
 
 .. _HBase: https://hbase.apache.org/
 
-.. DynamoDB: https://aws.amazon.com/dynamodb/
+.. _DynamoDB: https://aws.amazon.com/dynamodb/
+
+.. _localstack: https://github.com/localstack/localstack
+
+.. _boto3: https://aws.amazon.com/sdk-for-python
 
 That's all there is to it!

--- a/docs/user/usage.rst
+++ b/docs/user/usage.rst
@@ -68,7 +68,7 @@ Slack Machine comes with a few simple built-in plugins:
 - **EchoPlugin**: replies to any message the bot hears, with exactly the same message. The bot will
   reply to the same channel the original message was heard in
 
-By default, **HelloPlugin** and **PingPonPlugin** are enabled.
+By default, **HelloPlugin** and **PingPongPlugin** are enabled.
 
 You can specify which plugins Slack Machine should load, by setting the ``PLUGINS`` variable in
 ``local_settings.py`` to a list of fully qualified classes or modules that contain plugins.
@@ -156,7 +156,7 @@ Out of the box, Slack Machine provides 2 options for storage backend:
   - ``DYNAMODB_KEY_PREFIX``: an optional prefix to use within the key lookup. Defaults to `SM:`
   - ``DYNAMODB_TABLE_NAME``: specifies the table to use in DynamoDB. Defaults to `slack-machine-state`
   - ``DYNAMODB_CREATE_TABLE``: optionally -create- the table to be used in DynamoDB. Defaults to `False`
-  - ``DYNAMODB_CLIENT``: if custom configuration is needed for the DynamoDB client, an optional [boto3](https://aws.amazon.com/sdk-for-python/) client can be specified here
+  - ``DYNAMODB_CLIENT``: if custom configuration is needed for the DynamoDB client, an optional [boto3](https://aws.amazon.com/sdk-for-python) client can be specified here
   
   *Class*: ``machine.storage.backends.dynamodb.DynamoDBStorage``
 

--- a/machine/storage/backends/dynamodb.py
+++ b/machine/storage/backends/dynamodb.py
@@ -1,6 +1,8 @@
 import logging
 import datetime
 import calendar
+import pickle
+import codecs
 import boto3
 import botocore
 from machine.storage.backends.base import MachineBaseStorage
@@ -9,6 +11,28 @@ logger = logging.getLogger(__name__)
 
 
 class DynamoDBStorage(MachineBaseStorage):
+    """
+        A storage plugin to allow native slack-machine storage
+        into AWS DynamoDB
+
+        Configuration of the connection to AWS itself is done via
+        standard environment variables or pre-written configuration
+        files, such as ~/.aws/{config}
+
+        For local testing, the endpoint URL can be modified using
+        slack-machine setting `DYNAMODB_ENDPOINT_URL`
+
+        If `DYNAMODB_CREATE_TABLE` is set within slack-machine
+        settings, this driver will create the table in AWS automatically
+
+        Additionally, if you need a DynamoDB client to be customized,
+        a custom client can be passed in with the `DYNAMODB_CLIENT`
+        slack-machine setting
+
+        Data in DynamoDB is stored as a pickled base64 string to 
+        avoid complications in setting and fetching (bytes)
+    """
+
     def __init__(self, settings):
         super().__init__(settings)
         args = {}
@@ -50,9 +74,22 @@ class DynamoDBStorage(MachineBaseStorage):
         self._table = self._db.Table(self._table_name)
 
     def _prefix(self, key):
+        """
+            Given a slack-machine lookup key, generate a prefixed-key
+            to be used in the DynamoDB table lookup
+
+            :param key: the SM key to prefix
+        """
         return '{}:{}'.format(self._key_prefix, key)
 
     def has(self, key):
+        """
+            Check if the key exists in DynamoDB
+
+            :param key: the SM key to check
+            :return: ``True/False`` whether the key exists in DynamoDB
+            :raises ClientError: if the client was unable to communicate with DynamoDB
+        """
         try:
             r = self._table.get_item(Key={'sm-key': self._prefix(key)})
             return True if 'Item' in r else False
@@ -61,10 +98,19 @@ class DynamoDBStorage(MachineBaseStorage):
             raise e
 
     def get(self, key):
+        """
+            Retrieve item data by key
+
+            :param key: the SM key to fetch against
+            :return: the raw data for the provided key, as (byte)string. Returns ``None`` when
+                the key is unknown or the data has expired
+            :raises ClientError: if the client was unable to communicate with DynamoDB
+        """
         try:
             r = self._table.get_item(Key={'sm-key': self._prefix(key)})
             if 'Item' in r:
-                return r['Item']['sm-value']
+                v = r['Item']['sm-value']
+                return pickle.loads(codecs.decode(v.encode(), 'base64'))
             else:
                 return None
         except botocore.exceptions.ClientError as e:
@@ -72,9 +118,18 @@ class DynamoDBStorage(MachineBaseStorage):
             raise e
 
     def set(self, key, value, expires=None):
+        """
+            Store item data by key
+
+            :param key: the key under which to store the data
+            :param value: data as (byte)string
+            :param expires: optional expiration time in seconds, after which the
+                data should not be returned any more
+            :raises ClientError: if the client was unable to communicate with DynamoDB
+        """
         item = {
             'sm-key': self._prefix(key),
-            'sm-value': value
+            'sm-value': codecs.encode(pickle.dumps(value), 'base64').decode()
         }
         if expires:
             ttl = datetime.datetime.utcnow() + datetime.timedelta(seconds=expires)
@@ -84,13 +139,26 @@ class DynamoDBStorage(MachineBaseStorage):
             self._table.put_item(Item=item)
         except botocore.exceptions.ClientError as e:
             logger.error('Unable to set item[{}]'.format(self._prefix(key)))
+            raise e
 
     def delete(self, key):
+        """
+            Delete item data by key
+
+            :param key: key for which to delete the data
+            :raises ClientError: if the client was unable to communicate with DynamoDB
+        """
         try:
             self._table.delete_item(Key={'sm-key': self._prefix(key)})
         except botocore.exceptions.ClientError as e:
             logger.error('Unable to delete item[{}]'.format(self._prefix(key)))
+            raise e
 
     def size(self):
+        """
+            Calculate the total size of the storage
+
+            :return: total size of storage in bytes (integer)
+        """
         t = self._table.meta.client.describe_table(TableName=self._table_name)
         return t['Table']['TableSizeBytes']

--- a/machine/storage/backends/dynamodb.py
+++ b/machine/storage/backends/dynamodb.py
@@ -1,0 +1,96 @@
+import logging
+import datetime
+import calendar
+import boto3
+import botocore
+from machine.storage.backends.base import MachineBaseStorage
+
+logger = logging.getLogger(__name__)
+
+
+class DynamoDBStorage(MachineBaseStorage):
+    def __init__(self, settings):
+        super().__init__(settings)
+        args = {}
+        if 'DYNAMODB_ENDPOINT_URL' in settings:
+            args['endpoint_url'] = settings['DYNAMODB_ENDPOINT_URL']
+        self._key_prefix = settings.get('DYNAMODB_KEY_PREFIX', 'SM')
+        self._table_name = settings.get('DYNAMODB_TABLE_NAME', 'slack-machine-state')
+
+        if 'DYNAMODB_CLIENT' in settings:
+            self._db = settings['DYNAMODB_CLIENT']
+        else:
+            db = boto3.resource('dynamodb', **args)
+            self._db = db
+
+        create_table = settings.get('DYNAMODB_CREATE_TABLE', False)
+        if create_table:
+            try:
+                self._table = self._db.create_table(
+                    TableName=self._table_name,
+                    KeySchema=[
+                        {'AttributeName': 'sm-key', 'KeyType': 'HASH'}
+                    ],
+                    AttributeDefinitions=[
+                        {'AttributeName': 'sm-key', 'AttributeType': 'S'}
+                    ],
+                    BillingMode='PAY_PER_REQUEST'
+                )
+                self._table.meta.client.get_waiter('table_exists').wait(TableName=self._table_name)
+                ttl = {'Enabled': True, 'AttributeName': 'sm-expire'}
+                self._table.meta.client.update_time_to_live(
+                    TableName=self._table_name, TimeToLiveSpecification=ttl)
+            except botocore.exceptions.ClientError as e:
+                if e.response['Error']['Code'] == 'ResourceInUseException':
+                    logger.info(
+                        'DynamoDB table[{}] exists, skipping creation'.format(self._table_name))
+                else:
+                    raise e
+
+        self._table = self._db.Table(self._table_name)
+
+    def _prefix(self, key):
+        return '{}:{}'.format(self._key_prefix, key)
+
+    def has(self, key):
+        try:
+            r = self._table.get_item(Key={'sm-key': self._prefix(key)})
+            return True if 'Item' in r else False
+        except botocore.exceptions.ClientError as e:
+            logger.error('Unable to get item[{}]'.format(self._prefix(key)))
+            raise e
+
+    def get(self, key):
+        try:
+            r = self._table.get_item(Key={'sm-key': self._prefix(key)})
+            if 'Item' in r:
+                return r['Item']['sm-value']
+            else:
+                return None
+        except botocore.exceptions.ClientError as e:
+            logger.error('Unable to get item[{}]'.format(self._prefix(key)))
+            raise e
+
+    def set(self, key, value, expires=None):
+        item = {
+            'sm-key': self._prefix(key),
+            'sm-value': value
+        }
+        if expires:
+            ttl = datetime.datetime.utcnow() + datetime.timedelta(seconds=expires)
+            item['sm-expire'] = calendar.timegm(ttl.timetuple())
+
+        try:
+            self._table.put_item(Item=item)
+        except botocore.exceptions.ClientError as e:
+            logger.error('Unable to set item[{}]'.format(self._prefix(key)))
+
+    def delete(self, key):
+        try:
+            self._table.delete_item(Key={'sm-key': self._prefix(key)})
+        except botocore.exceptions.ClientError as e:
+            logger.error('Unable to delete item[{}]'.format(self._prefix(key)))
+
+    def size(self):
+        t = self._table.meta.client.describe_table(TableName=self._table_name)
+        return t['Table']['TableSizeBytes']

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,8 @@ setup(
     python_requires='~=3.6',
     extras_require={
         'redis': ['redis', 'hiredis'],
-        'hbase': ['Cython==0.29.6', 'happybase']
+        'hbase': ['Cython==0.29.6', 'happybase'],
+        'dynamodb': ['boto3==1.17.36', 'moto==1.3.15']
     },
     classifiers=[
         "Development Status :: 4 - Beta",

--- a/tests/test_dynamodb_storage.py
+++ b/tests/test_dynamodb_storage.py
@@ -1,0 +1,49 @@
+import os
+import pytest
+import boto3
+import time
+from moto import mock_dynamodb2
+from machine.storage.backends.dynamodb import DynamoDBStorage
+
+
+@pytest.fixture
+def dynamodb_storage():
+    with mock_dynamodb2():
+        os.environ['AWS_DEFAULT_REGION'] = 'us-east-1'
+        os.environ['AWS_ACCESS_KEY_ID'] = 'dummy'
+        os.environ['AWS_SECRET_ACCESS_KEY'] = 'dummy'
+        db = boto3.resource('dynamodb')
+        settings = {
+            'DYNAMODB_CREATE_TABLE': True,
+            'DYNAMODB_ENDPOINT_URL': 'http://dummy',
+            'DYNAMODB_CLIENT': db
+        }
+        yield DynamoDBStorage(settings)
+
+
+def test_store_retrieve_values(dynamodb_storage):
+    assert dynamodb_storage.get('key_invalid') is None
+    dynamodb_storage.set('key1', 'value1')
+    assert dynamodb_storage.get('key1') == 'value1'
+    dynamodb_storage.set('key2', 'value2', 2)
+    assert dynamodb_storage.get('key2') == 'value2'
+    r = dynamodb_storage._table.get_item(Key={'sm-key': dynamodb_storage._prefix('key2')})
+    assert r['Item']['sm-expire'] > 0
+
+
+def test_has(dynamodb_storage):
+    dynamodb_storage.set('key1', 'value1')
+    assert dynamodb_storage.has('key1')
+    assert dynamodb_storage.has('key2') == False
+
+
+def test_delete(dynamodb_storage):
+    dynamodb_storage.set('key1', 'value1')
+    assert dynamodb_storage.has('key1')
+    assert dynamodb_storage.get('key1') == 'value1'
+    dynamodb_storage.delete('key1')
+    assert dynamodb_storage.has('key1') == False
+
+
+def test_size(dynamodb_storage):
+    assert isinstance(dynamodb_storage.size(), int)


### PR DESCRIPTION
A storage plugin to allow storing slack-machine data into AWS DynamoDB

Optional slack-machine settings introduced:

`DYNAMODB_ENDPOINT_URL` - specifies an optional alternate endpoint, for local bot testing
`DYNAMODB_KEY_PREFIX` - an optional prefix to use within the key lookup. Defaults to `SM:`
`DYNAMODB_TABLE_NAME` - specifies the table to use in DynamoDB. Defaults to `slack-machine-state`
`DYNAMODB_CREATE_TABLE` - optionally -create- the table to be used in DynamoDB. Defaults to `False`
`DYNAMODB_CLIENT` - if custom configuration is needed for the DynamoDB client, an optional client can be specified here