### PR TITLE
Added init_final() as an alternative to init()

### DIFF
--- a/machine/core.py
+++ b/machine/core.py
@@ -77,6 +77,7 @@ class Machine:
     def load_plugins(self):
         with indent(4):
             logger.debug("PLUGINS: %s", self._settings['PLUGINS'])
+            self._plugins = []
             for plugin in self._settings['PLUGINS']:
                 for class_name, cls in import_string(plugin):
                     if issubclass(cls, MachineBasePlugin) and cls is not MachineBasePlugin:
@@ -95,6 +96,7 @@ class Machine:
                             del instance
                         else:
                             instance.init()
+                            self._plugins.append([instance, class_name])
                             show_valid(class_name)
         self._storage.set('manual', dill.dumps(self._help))
 
@@ -208,4 +210,4 @@ class Machine:
                 )
 
             show_valid("Dispatcher started")
-            self._dispatcher.start()
+            self._dispatcher.start(self._plugins)

--- a/machine/dispatch.py
+++ b/machine/dispatch.py
@@ -28,10 +28,10 @@ class EventDispatcher:
             re.DOTALL,
         )
 
-    def start(self):
+    def start(self, plugins):
         RTMClient.on(event='pong', callback=self.pong)
         RTMClient.on(event='message', callback=self.handle_message)
-        self._client.start()
+        self._client.start(plugins)
 
     def pong(self, **kwargs):
         logger.debug("Server Pong!")

--- a/machine/plugins/base.py
+++ b/machine/plugins/base.py
@@ -40,6 +40,18 @@ class MachineBasePlugin:
         for each plugin, when that plugin is first loaded. You can refer to settings via
         ``self.settings``, and access storage through ``self.storage``, but the Slack client has
         not been initialized yet, so you cannot send or process messages during initialization.
+        For initialization after the Slack client use ``init_final``
+
+        :return: None
+        """
+        pass
+
+    def init_final(self):
+        """Final initialization of plugin
+
+        This method can be implemented by concrete plugin classes. It will be called **once**
+        for each plugin, **after** that the Slack client has been initialized. You can refer to
+        settings via ``self.settings``, and access storage through ``self.storage``.
 
         :return: None
         """


### PR DESCRIPTION
init() in the MachineBaseplugin is called before Slack is initialized, which can be annoying if you wan to initialize something that needs some info from Slack, for instance channel names.
This adds init_final() to MachineBasePlugin which is called after the initialization of Slack after the channels, users etc are loaded.

I'm not sure if init_final() is the best name so any suggestions for a better name would be welcome, and ofc any other feedback too. Also let me know if any tests or docs need to be updated too.