### PR TITLE
Fix doc typos

### DIFF
--- a/docs/plugins/basics.md
+++ b/docs/plugins/basics.md
@@ -51,7 +51,7 @@ class UltimateQuestionPlugin(MachineBasePlugin):
     @listen_to(regex=r"^42$")
     async def question(self, msg):
         await msg.say("You're telling me the Answer to the Ultimate Question of Life, the Universe and Everything, ",
-                      "but I don"t know the question :cry:")
+                      "but I don't know the question :cry:")
 ```
 
 !!! tip

--- a/docs/user/usage.md
+++ b/docs/user/usage.md
@@ -19,7 +19,7 @@ Once you have installed Slack Machine, configuring and starting your bot is easy
     SLACK_BOT_TOKEN = "xoxb-my-bot-token"
     ```
 
-7. Start the bot with `slack-machine-async`
+7. Start the bot with `slack-machine`
 8. ...
 9. Profit!
 


### PR DESCRIPTION
- Double-quote typo
- `slack-machine-async` doesn't exist, use `slack-machine`