### PR TITLE
Added ShelfStorage, using the shelve module. 

### DIFF
--- a/docs/user/usage.md
+++ b/docs/user/usage.md
@@ -129,6 +129,24 @@ dependencies. **Does not persist data between restarts**
 
 *Class*: `machine.storage.backends.memory.MemoryStorage`
 
+#### Shelve:
+
+This backend stores data using the [shelve](https://docs.python.org/3/library/shelve.html) package.
+Shelve is module of the Python standard library that provides a persistent,
+dictionary-like object that is stored in a file.
+It serves as a very simple way to provide cross-session persistent storage for the slack-machine. Objects in a shelf are pickled, so the usual warnings apply about pickling.
+
+Required Parameters:
+- `STORAGE_FILE`:  Name of the file(s) that ShelfStorage will create and utilize. Do not provide an extension. Example: `path/to/storage_file`
+
+The storage will be persisted in a set of files.  Removing these files will reset the storage.
+- `path/to/storage_file.dat`
+- `path/to/storage_file.dir`
+- `path/to/storage_file.bak`
+
+
+*Class*: `machine.storage.backends.shelve.ShelfStorage`
+
 #### Redis:
 
 This backend stores data in [Redis](https://redis.io/). Redis is a very fast key-value store that is super easy to

--- a/machine/storage/backends/shelve.py
+++ b/machine/storage/backends/shelve.py
@@ -1,0 +1,78 @@
+from typing import Any, Mapping
+
+import shelve
+import atexit
+from datetime import datetime, timedelta
+
+from machine.storage.backends.base import MachineBaseStorage
+from machine.plugins.decorators import required_settings
+
+
+@required_settings(['STORAGE_FILE'])
+class ShelfStorage(MachineBaseStorage):
+    """ Shelve is module of the Python standard library that provides a
+    persistent, dictionary-like object that is stored in a file.  It
+    serves as a very simple way to provide cross-session persistent storage
+    for the slack-machine.
+
+    Objects in a shelf are pickled, so the usual warnings apply about
+    pickling.
+
+    To use this module, include in your setting file:
+    STORAGE_BACKEND = 'machine.storage.backends.shelve.ShelfStorage'
+    STORAGE_FILE = 'path/to/file'  # Do not provide an extension.
+
+    The storage will be created in a set of files
+    path/to/file.dat
+    path/to/file.dir
+    path/to/file.bak
+    """
+    settings: Mapping[str, Any]
+    _storage: shelve.Shelf
+
+    def __init__(self, settings: Mapping[str, Any]):
+        super().__init__(settings)
+        storage_file = settings['STORAGE_FILE']
+        self._storage = shelve.open(storage_file, 'c')
+        atexit.register(self._cleanup)
+
+    def _cleanup(self):
+        self._storage.close()
+
+    async def get(self, key: str) -> bytes | None:
+        stored = self._storage.get(key, None)
+        if stored is None:
+            return None
+        else:
+            if stored[1] and stored[1] < datetime.utcnow():
+                del self._storage[key]
+                return None
+            else:
+                return stored[0]
+
+    async def set(self, key: str, value: bytes, expires: int | None = None) -> None:
+        if expires:
+            expires_at = datetime.utcnow() + timedelta(seconds=expires)
+        else:
+            expires_at = None
+        self._storage[key] = (value, expires_at)
+
+    async def has(self, key: str) -> bool:
+        stored = self._storage.get(key, None)
+        if stored is None:
+            return False
+        else:
+            if stored[1] and stored[1] < datetime.utcnow():
+                del self._storage[key]
+                return False
+            else:
+                return True
+
+    async def delete(self, key: str) -> None:
+        del self._storage[key]
+
+    async def size(self) -> int:
+        return 0
+
+    async def close(self) -> None:
+        self._cleanup()

--- a/tests/storage/backends/test_shelve_storage.py
+++ b/tests/storage/backends/test_shelve_storage.py
@@ -1,0 +1,46 @@
+from datetime import datetime
+import asyncio
+
+import pytest
+
+from machine.storage.backends.shelve import ShelfStorage
+
+
+@pytest.fixture
+def shelf_storage():
+    return ShelfStorage({'STORAGE_FILE': 'shelve_test'})
+
+
+@pytest.mark.asyncio
+async def test_store_retrieve_values(shelf_storage):
+    await shelf_storage.set("key1", "value1")
+    assert shelf_storage._storage == {"key1": ("value1", None)}
+    assert await shelf_storage.get("key1") == "value1"
+
+
+@pytest.mark.asyncio
+async def test_delete_values(shelf_storage):
+    await shelf_storage.set("key1", "value1")
+    await shelf_storage.set("key2", "value2")
+    assert shelf_storage._storage == {"key1": ("value1", None), "key2": ("value2", None)}
+    await shelf_storage.delete("key2")
+    assert shelf_storage._storage == {"key1": ("value1", None)}
+
+
+@pytest.mark.asyncio
+async def test_expire_values(shelf_storage, mocker):
+    mocked_dt = mocker.patch("machine.storage.backends.shelve.datetime", autospec=True)
+    mocked_dt.utcnow.return_value = datetime(2017, 1, 1, 12, 0, 0, 0)
+    await shelf_storage.set("key1", "value1", expires=15)
+    assert shelf_storage._storage['key1'] == ("value1", datetime(2017, 1, 1, 12, 0, 15, 0))
+    assert await shelf_storage.get("key1") == "value1"
+    mocked_dt.utcnow.return_value = datetime(2017, 1, 1, 12, 0, 20, 0)
+    assert await shelf_storage.get("key1") is None
+
+
+@pytest.mark.asyncio
+async def test_inclusion(shelf_storage):
+    await shelf_storage.set("key1", "value1")
+    assert await shelf_storage.has("key1") is True
+    await shelf_storage.delete("key1")
+    assert await shelf_storage.has("key1") is False


### PR DESCRIPTION
I wanted a persistent storage option that is lightweight, so I implemented one using the [shelve](https://docs.python.org/3/library/shelve.html) module.   It's basically a python dictionary in the file-system, instead of memory.   I've been using it for a little while, now, and it seems to work.  

I modified the existing tests from the MemoryStorage module, and they pass for ShelfStorage.  

