### PR TITLE
fix: use conversations_setTopic instead of channels_setTopic

### DIFF
--- a/machine/clients/slack.py
+++ b/machine/clients/slack.py
@@ -265,4 +265,4 @@ class SlackClient:
 
     async def set_topic(self, channel: Channel | str, topic: str, **kwargs: Any) -> AsyncSlackResponse:
         channel_id = id_for_channel(channel)
-        return await self._client.web_client.channels_setTopic(channel=channel_id, topic=topic, **kwargs)
+        return await self._client.web_client.conversations_setTopic(channel=channel_id, topic=topic, **kwargs)


### PR DESCRIPTION
Look like `channels_setTopic` is not supported by Slack APIs anymore. Rather [`conversations_setTopic`](https://api.slack.com/methods/conversations.setTopic) is available to set topics for a channel.