### PR TITLE
Rate Limit Handling for Resilient Slack API Interaction

### DIFF
--- a/machine/clients/slack.py
+++ b/machine/clients/slack.py
@@ -4,6 +4,7 @@ import sys
 from datetime import datetime
 from typing import Any, Awaitable, Callable
 
+import asyncio
 from slack_sdk.errors import SlackApiError
 from slack_sdk.socket_mode.aiohttp import SocketModeClient
 from slack_sdk.socket_mode.async_client import AsyncBaseSocketModeClient
@@ -112,7 +113,7 @@ class SlackClient:
 
             except SlackApiError as e:
                 # Handle rate limiting
-                if e.response is 429:
+                if e.response == 429:
                     retry_after = int(e.response.headers.get("Retry-After", 1))
                     logger.warning(f"Rate limit hit. Retrying after {retry_after} seconds...")
                     await asyncio.sleep(retry_after)
@@ -145,7 +146,7 @@ class SlackClient:
 
             except SlackApiError as e:
                 # Handle rate limiting
-                if e.response is 429:
+                if e.response == 429:
                     retry_after = int(e.response.headers.get("Retry-After", 1))
                     logger.warning(f"Rate limit hit. Retrying after {retry_after} seconds...")
                     await asyncio.sleep(retry_after)

--- a/machine/clients/slack.py
+++ b/machine/clients/slack.py
@@ -102,7 +102,7 @@ class SlackClient:
         while True:
             try:
                 # Fetch the users list with pagination
-                response = await client.web_client.users_list(limit=5000, cursor=cursor)
+                response = await client.web_client.users_list(limit=1000, cursor=cursor)
                 all_users += response["members"]
                 cursor = response.get("response_metadata", {}).get("next_cursor")
 
@@ -113,7 +113,7 @@ class SlackClient:
 
             except SlackApiError as e:
                 # Handle rate limiting
-                if e.response == 429:
+                if e.response["error"] == "ratelimited":
                     retry_after = int(e.response.headers.get("Retry-After", 1))
                     logger.warning(f"Rate limit hit. Retrying after {retry_after} seconds...")
                     await asyncio.sleep(retry_after)
@@ -144,7 +144,7 @@ class SlackClient:
 
             except SlackApiError as e:
                 # Handle rate limiting
-                if e.response == 429:
+                if e.response["error"] == "ratelimited":
                     retry_after = int(e.response.headers.get("Retry-After", 1))
                     logger.warning(f"Rate limit hit. Retrying after {retry_after} seconds...")
                     await asyncio.sleep(retry_after)

--- a/machine/clients/slack.py
+++ b/machine/clients/slack.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
+import asyncio
 import sys
 from datetime import datetime
 from typing import Any, Awaitable, Callable
 
-import asyncio
 from slack_sdk.errors import SlackApiError
 from slack_sdk.socket_mode.aiohttp import SocketModeClient
 from slack_sdk.socket_mode.async_client import AsyncBaseSocketModeClient
@@ -132,9 +132,7 @@ class SlackClient:
             try:
                 # Fetch the conversations list with pagination
                 response = await client.web_client.conversations_list(
-                    limit=1000,
-                    types="public_channel,private_channel,mpim,im",
-                    cursor=cursor
+                    limit=1000, types="public_channel,private_channel,mpim,im", cursor=cursor
                 )
                 all_channels += response["channels"]
                 cursor = response.get("response_metadata", {}).get("next_cursor")

--- a/machine/clients/slack.py
+++ b/machine/clients/slack.py
@@ -45,7 +45,9 @@ def rate_limit_retry(func):
     async def wrapper(self, *args, **kwargs):
         while True:
             try:
-                return await func(self, *args, **kwargs)
+                async for item in func(self, *args, **kwargs):
+                    yield item
+                break
             except SlackApiError as e:
                 if e.response["error"] == "ratelimited":
                     retry_after = int(e.response.headers.get("Retry-After", 1))

--- a/machine/clients/slack.py
+++ b/machine/clients/slack.py
@@ -94,8 +94,8 @@ class SlackClient:
             elif event["type"] == "member_joined_channel":
                 await self._on_member_joined_channel(event)
 
-    async def fetch_all_users(client):
-        all_users = []
+    async def fetch_all_users(client) -> list[dict[str, Any]]:
+        all_users: list[dict[str, Any]] = []
         cursor = None
 
         while True:
@@ -118,18 +118,13 @@ class SlackClient:
                     await asyncio.sleep(retry_after)
                 else:
                     # Handle other Slack API errors
-                    logger.error(f"Error fetching channels: {e.response['error']}")
-                    break
-
-            except Exception as e:
-                # Handle any other exceptions
-                logger.error(f"Unexpected error: {e}")
-                break
+                    logger.error(f"Error fetching users: {e.response['error']}")
+                    raise e
 
         return all_users
 
-    async def fetch_all_channels(client) -> List[Dict[str, Any]]:
-        all_channels: List[Dict[str, Any]] = []
+    async def fetch_all_channels(client) -> list[dict[str, Any]]:
+        all_channels: list[dict[str, Any]] = []
         cursor = None
 
         while True:
@@ -157,16 +152,9 @@ class SlackClient:
                 else:
                     # Handle other Slack API errors
                     logger.error(f"Error fetching channels: {e.response['error']}")
-                    break
-
-            except Exception as e:
-                # Handle any other exceptions
-                logger.error(f"Unexpected error: {e}")
-                break
+                    raise e
 
         return all_channels
-
-
 
     async def setup(self) -> None:
         # Setup handlers


### PR DESCRIPTION
## Summary
This PR introduces asynchronous rate limit handling to improve Slack Machine’s resilience when interacting with the Slack API. By incorporating error management for `SlackApiError` and implementing a retry mechanism, this update aims to minimize disruptions during high-volume API requests and ensure the bot doesn't fail to start under rate-limiting conditions, such as when there are thousands of users and/or channels.

Fixes https://github.com/DonDebonair/slack-machine/issues/975

## Changes

1. **Rate Limit Management**: Adds handling for `SlackApiError` with specific checks for rate-limiting errors, allowing the bot to pause and retry when limits are hit.
2. **Pagination and Caching**: Introduces `build_paginated_cache`, a method for managing paginated API responses, enabling smoother and more efficient data handling.

## Motivation

Slack’s API rate limits can cause disruptions in bot functionality, especially in high-demand environments. This PR adds rate limit handling to Slack Machine, providing a smoother, more resilient user experience.

## Testing

All changes have been tested locally under various rate-limit scenarios to confirm proper error handling and retry logic.