### PR TITLE
Allow any enterprise

### DIFF
--- a/src/machine/models/interactive.py
+++ b/src/machine/models/interactive.py
@@ -391,7 +391,7 @@ class BlockActionsPayload(TypedModel):
     container: Container
     trigger_id: str
     team: Team
-    enterprise: str | None
+    enterprise: Any | None
     is_enterprise_install: bool
     channel: Channel | None = None
     message: Message | None = None
@@ -419,7 +419,7 @@ class ViewSubmissionPayload(TypedModel):
     team: Team
     user: User
     view: View
-    enterprise: str | None
+    enterprise: Any | None
     api_app_id: str
     token: str
     trigger_id: str
@@ -432,7 +432,7 @@ class ViewClosedPayload(TypedModel):
     team: Team
     user: User
     view: View
-    enterprise: str | None
+    enterprise: Any | None
     api_app_id: str
     token: str
     is_cleared: bool

--- a/tests/models/example_payloads/block_action_button_enterprise.py
+++ b/tests/models/example_payloads/block_action_button_enterprise.py
@@ -1,0 +1,148 @@
+payload = {
+    "type": "block_actions",
+    "user": {"id": "UQEUMSA0K", "username": "daan", "name": "daan", "team_id": "TQSD32X16"},
+    "api_app_id": "A039QKQ6G1E",
+    "token": "ZMBw88SmAGYGpwguEEH4bZ84",
+    "container": {
+        "type": "message",
+        "message_ts": "1716206801.973899",
+        "channel_id": "CQEUMSV7D",
+        "is_ephemeral": False,
+    },
+    "trigger_id": "7146094638420.842445099040.8fbb84c74d488a7ec2646219cbb845a1",
+    "team": {"id": "TQSD32X16", "domain": "dandydev"},
+    "enterprise": {"id": "E039QKQ6G1E", "name": "DandyDev"},
+    "is_enterprise_install": True,
+    "channel": {"id": "CQEUMSV7D", "name": "general"},
+    "message": {
+        "user": "U038Y1G7745",
+        "type": "message",
+        "ts": "1716206801.973899",
+        "bot_id": "B0390TCABQB",
+        "app_id": "A039QKQ6G1E",
+        "text": "Vote for lunch",
+        "team": "TQSD32X16",
+        "blocks": [
+            {
+                "type": "section",
+                "block_id": "5wxLW",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": "*Where should we order lunch from?* Poll by <fakeLink.toUser.com|Mark>",
+                    "verbatim": False,
+                },
+            },
+            {"type": "divider", "block_id": "VcIxg"},
+            {
+                "type": "section",
+                "block_id": "q3Yif",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": ":sushi: *Ace Wasabi Rock-n-Roll Sushi Bar*\nThe best landlocked sushi restaurant.",
+                    "verbatim": False,
+                },
+                "accessory": {
+                    "type": "button",
+                    "action_id": "sushi",
+                    "text": {"type": "plain_text", "text": "Vote", "emoji": True},
+                },
+            },
+            {
+                "type": "context",
+                "block_id": "aLe7H",
+                "elements": [
+                    {
+                        "type": "image",
+                        "image_url": "https://api.slack.com/img/blocks/bkb_template_images/profile_1.png",
+                        "alt_text": "Michael Scott",
+                    },
+                    {
+                        "type": "image",
+                        "image_url": "https://api.slack.com/img/blocks/bkb_template_images/profile_2.png",
+                        "alt_text": "Dwight Schrute",
+                    },
+                    {
+                        "type": "image",
+                        "image_url": "https://api.slack.com/img/blocks/bkb_template_images/profile_3.png",
+                        "alt_text": "Pam Beasely",
+                    },
+                    {"type": "plain_text", "text": "3 votes", "emoji": True},
+                ],
+            },
+            {
+                "type": "section",
+                "block_id": "iwv9r",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": ":hamburger: *Super Hungryman Hamburgers*\nOnly for the hungriest of the hungry.",
+                    "verbatim": False,
+                },
+                "accessory": {
+                    "type": "button",
+                    "action_id": "hamburger",
+                    "text": {"type": "plain_text", "text": "Vote", "emoji": True},
+                },
+            },
+            {
+                "type": "context",
+                "block_id": "IUs3i",
+                "elements": [
+                    {
+                        "type": "image",
+                        "image_url": "https://api.slack.com/img/blocks/bkb_template_images/profile_4.png",
+                        "alt_text": "Angela",
+                    },
+                    {
+                        "type": "image",
+                        "image_url": "https://api.slack.com/img/blocks/bkb_template_images/profile_2.png",
+                        "alt_text": "Dwight Schrute",
+                    },
+                    {"type": "plain_text", "text": "2 votes", "emoji": True},
+                ],
+            },
+            {
+                "type": "section",
+                "block_id": "n5Exn",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": ":ramen: *Kagawa-Ya Udon Noodle Shop*\nDo you like to shop for noodles? We have noodles.",
+                    "verbatim": False,
+                },
+                "accessory": {
+                    "type": "button",
+                    "action_id": "ramen",
+                    "text": {"type": "plain_text", "text": "Vote", "emoji": True},
+                },
+            },
+            {
+                "type": "context",
+                "block_id": "DRo0X",
+                "elements": [{"type": "mrkdwn", "text": "No votes", "verbatim": False}],
+            },
+            {"type": "divider", "block_id": "fSYFi"},
+            {
+                "type": "actions",
+                "block_id": "C7q4o",
+                "elements": [
+                    {
+                        "type": "button",
+                        "action_id": "hsnL4",
+                        "text": {"type": "plain_text", "text": "Add a suggestion", "emoji": True},
+                        "value": "click_me_123",
+                    }
+                ],
+            },
+        ],
+    },
+    "state": {"values": {}},
+    "response_url": "https://hooks.slack.com/actions/TQSD32X16/7156287676161/TySSUfp835V0G9PQk8Z5pN3w",
+    "actions": [
+        {
+            "action_id": "sushi",
+            "block_id": "q3Yif",
+            "text": {"type": "plain_text", "text": "Vote", "emoji": True},
+            "type": "button",
+            "action_ts": "1716206811.107343",
+        }
+    ],
+}

--- a/tests/models/test_block_actions.py
+++ b/tests/models/test_block_actions.py
@@ -2,6 +2,7 @@ from machine.models.interactive import BlockActionsPayload, InteractivePayload
 from tests.models.example_payloads.block_action_button import payload as button_payload
 from tests.models.example_payloads.block_action_button2 import payload as button_payload2
 from tests.models.example_payloads.block_action_button_no_value import payload as button_no_value_payload
+from tests.models.example_payloads.block_action_button_enterprise import payload as button_enterprise_payload
 from tests.models.example_payloads.block_action_checkboxes import payload as checkboxes_payload
 from tests.models.example_payloads.block_action_checkboxes2 import payload as checkboxes_payload2
 from tests.models.example_payloads.block_action_datepicker import payload as datepicker_payload
@@ -33,6 +34,12 @@ def test_block_action_button():
     validated_button_no_value_payload = InteractivePayload.validate_python(button_no_value_payload)
     assert validated_button_no_value_payload is not None
     assert isinstance(validated_button_no_value_payload, BlockActionsPayload)
+
+
+def test_block_action_button_enterprise():
+    validated_button_enterprise_payload = InteractivePayload.validate_python(button_enterprise_payload)
+    assert validated_button_enterprise_payload is not None
+    assert isinstance(validated_button_enterprise_payload, BlockActionsPayload)
 
 
 def test_block_action_checkboxes():


### PR DESCRIPTION
## What
* Allows `Any` type for the `enterprise` key of an interactive payload
* Adds test for enterprise in the form `{"id": "...", "name": "..."}`

## Why
We love slack machine for building interactive chatbots at my work, but I hit a snag when I tried to configure a button to open a modal.  It turns out that the Slack API response `enterprise` key didn't match the pydantic models in this project.  The model expects a `str`, but the Slack API returns a `dict` in the form `{"id": "...", "name": "..."}`.

After digging through this project, I saw that no test cases simulated an enterprise grid slack payload, and that the `enterprise` key was never even used.  Rather than update the model to strictly match the `dict` form, I figure the safest approach is to be fully permissive with the `Any` type.  To make it clear to the reader that this field is nullable, I left the `| None` union type.

See this original error message with my org ID masked:

```
Traceback (most recent call last):
 File "/opt/venv/lib/python3.12/site-packages/slack_sdk/socket_mode/async_client.py", line 156, in run_message_listeners
 await listener(self, request) # type: ignore
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 File "/opt/venv/lib/python3.12/site-packages/machine/handlers/interactive_handler.py", line 38, in handle_interactive_request
 parsed_payload = InteractivePayload.validate_python(request.payload)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 File "/opt/venv/lib/python3.12/site-packages/pydantic/type_adapter.py", line 412, in validate_python
 return self.validator.validate_python(
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pydantic_core._pydantic_core.ValidationError: 1 validation error for tagged-union[function-after[validate_view_or_message(), BlockActionsPayload],ViewSubmissionPayload,ViewClosedPayload]
block_actions.enterprise
 Input should be a valid string [type=string_type, input_value={'id': '***MASKED***', 'name': '***MASKED***'}, input_type=dict]
 For further information visit https://errors.pydantic.dev/2.10/v/string_type
```

## Testing

### New Failing Case
First, I added a failing test case to replicate my error.

```
-> uvx nox -s test -p 3.12
nox > Running session test-3.12
nox > Creating virtual environment (uv) using python3.12 in .nox/test-3-12
nox > /Users/zotavka/.local/share/mise/installs/uv/0.8.11/uv-aarch64-apple-darwin/uv sync --python=3.12 --group=dev
Resolved 116 packages in 5ms
Installed 83 packages in 136ms
 + aioboto3==15.0.0
 + aiobotocore==2.23.0
 + aiofiles==24.1.0
 + aiohappyeyeballs==2.4.3
 + aiohttp==3.11.7
 + aioitertools==0.12.0
 + aiosignal==1.3.1
 + aiosqlite==0.21.0
 + annotated-types==0.7.0
 + anyio==4.6.2.post1
 + apscheduler==3.10.4
 + argcomplete==3.5.1
 + attrs==24.2.0
 + boto3==1.38.27
 + botocore==1.38.27
 + botocore-stubs==1.35.68
 + certifi==2024.8.30
 + cffi==1.17.1
 + cfgv==3.4.0
 + colorlog==6.9.0
 + coverage==7.6.7
 + cryptography==43.0.3
 + dill==0.3.9
 + distlib==0.3.9
 + filelock==3.16.1
 + frozenlist==1.5.0
 + h11==0.14.0
 + httpcore==1.0.7
 + httpx==0.28.0
 + identify==2.6.2
 + idna==3.10
 + iniconfig==2.0.0
 + jmespath==1.0.1
 + mock==5.1.0
 + multidict==6.1.0
 + mypy==1.14.0
 + mypy-extensions==1.0.0
 + nodeenv==1.9.1
 + nox==2024.10.9
 + packaging==24.2
 + platformdirs==4.3.6
 + pluggy==1.5.0
 + pre-commit==4.0.1
 + propcache==0.2.0
 + pycparser==2.22
 + pydantic==2.10.1
 + pydantic-core==2.27.1
 + pyee==13.0.0
 + pytest==8.3.3
 + pytest-asyncio==1.1.0
 + pytest-cov==6.0.0
 + pytest-mock==3.14.0
 + python-dateutil==2.9.0.post0
 + pytz==2024.2
 + pyyaml==6.0.2
 + redis==6.4.0
 + ruff==0.12.0
 + s3transfer==0.13.0
 + six==1.16.0
 + slack-machine==0.40.0 (from file:///Users/zotavka/Developer/slack-machine)
 + slack-sdk==3.33.4
 + sniffio==1.3.1
 + structlog==25.4.0
 + types-aiobotocore==2.15.2.post1
 + types-aiobotocore-cloudformation==2.15.2
 + types-aiobotocore-dynamodb==2.15.2
 + types-aiobotocore-ec2==2.15.2
 + types-aiobotocore-lambda==2.15.2
 + types-aiobotocore-rds==2.15.2
 + types-aiobotocore-s3==2.15.2
 + types-aiobotocore-sqs==2.15.2
 + types-awscrt==0.23.0
 + types-cffi==1.16.0.20240331
 + types-pyopenssl==24.1.0.20240722
 + types-redis==4.6.0.20241004
 + types-setuptools==75.5.0.20241122
 + typing-extensions==4.12.2
 + tzdata==2025.2
 + tzlocal==5.2
 + urllib3==1.26.20
 + virtualenv==20.27.1
 + wrapt==1.17.0
 + yarl==1.18.0
nox > pytest 
================================== test session starts ===================================
platform darwin -- Python 3.12.2, pytest-8.3.3, pluggy-1.5.0 -- /Users/zotavka/Developer/slack-machine/.nox/test-3-12/bin/python3
cachedir: .pytest_cache
rootdir: /Users/zotavka/Developer/slack-machine
configfile: pyproject.toml
plugins: cov-6.0.0, asyncio-1.1.0, mock-3.14.0, anyio-4.6.2.post1
asyncio: mode=Mode.STRICT, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
collected 101 items                                                                      

tests/clients/test_slack_client.py::test_id_for_user PASSED                        [  0%]
tests/clients/test_slack_client.py::test_id_for_channel PASSED                     [  1%]
tests/clients/test_slack_client.py::test_register_handler PASSED                   [  2%]
tests/clients/test_slack_client.py::test_process_users_channels PASSED             [  3%]
tests/clients/test_slack_client.py::test_process_users_channels_team_join PASSED   [  4%]
tests/clients/test_slack_client.py::test_process_users_channels_team_join_no_email PASSED [  5%]
tests/clients/test_slack_client.py::test_process_users_channels_user_change PASSED [  6%]
tests/clients/test_slack_client.py::test_process_users_channels_channel_created PASSED [  7%]
tests/clients/test_slack_client.py::test_process_users_channels_channel_deleted PASSED [  8%]
tests/clients/test_slack_client.py::test_process_users_channels_channel_rename PASSED [  9%]
tests/clients/test_slack_client.py::test_process_users_channels_channel_archive PASSED [ 10%]
tests/clients/test_slack_client.py::test_get_user_by_id PASSED                     [ 11%]
tests/clients/test_slack_client.py::test_get_user_by_email PASSED                  [ 12%]
tests/handlers/test_command_handler.py::test_create_slash_command_handler PASSED   [ 13%]
tests/handlers/test_command_handler.py::test_create_slash_command_handler_generator PASSED [ 14%]
tests/handlers/test_event_handler.py::test_create_generic_event_handler PASSED     [ 15%]
tests/handlers/test_interactive_handler.py::test_matches PASSED                    [ 16%]
tests/handlers/test_interactive_handler.py::test_create_interactive_handler_for_block_actions PASSED [ 17%]
tests/handlers/test_interactive_handler.py::test_create_interactive_handler_for_view_submission PASSED [ 18%]
tests/handlers/test_interactive_handler.py::test_create_interactive_handler_for_view_submission_generator PASSED [ 19%]
tests/handlers/test_interactive_handler.py::test_create_interactive_handler_for_view_closed PASSED [ 20%]
tests/handlers/test_logging.py::test_request_logger_handler PASSED                 [ 21%]
tests/handlers/test_message_handler.py::test_generate_message_matcher PASSED       [ 22%]
tests/handlers/test_message_handler.py::test_check_bot_mention PASSED              [ 23%]
tests/handlers/test_message_handler.py::test_handle_message_listen_to PASSED       [ 24%]
tests/handlers/test_message_handler.py::test_handle_message_respond_to PASSED      [ 25%]
tests/handlers/test_message_handler.py::test_handle_message_changed PASSED         [ 26%]
tests/models/test_block_actions.py::test_block_action_radio_button PASSED          [ 27%]
tests/models/test_block_actions.py::test_block_action_button PASSED                [ 28%]
tests/models/test_block_actions.py::test_block_action_button_enterprise FAILED     [ 29%]
tests/models/test_block_actions.py::test_block_action_checkboxes PASSED            [ 30%]
tests/models/test_block_actions.py::test_block_action_datepicker PASSED            [ 31%]
tests/models/test_block_actions.py::test_block_action_static_select PASSED         [ 32%]
tests/models/test_block_actions.py::test_block_action_conversations_select PASSED  [ 33%]
tests/models/test_block_actions.py::test_block_action_multi_static_select PASSED   [ 34%]
tests/models/test_block_actions.py::test_block_action_multi_channels_select PASSED [ 35%]
tests/models/test_block_actions.py::test_block_action_timepicker PASSED            [ 36%]
tests/models/test_block_actions.py::test_block_action_url_input PASSED             [ 37%]
tests/models/test_block_actions.py::test_block_action_overflow PASSED              [ 38%]
tests/models/test_block_actions.py::test_block_action_in_modal PASSED              [ 39%]
tests/models/test_channel.py::test_identifier_without_name PASSED                  [ 40%]
tests/models/test_channel.py::test_identifier_with_name PASSED                     [ 41%]
tests/models/test_user.py::test_fmt_mention PASSED                                 [ 42%]
tests/models/test_views.py::test_view_submission PASSED                            [ 43%]
tests/models/test_views.py::test_view_closed PASSED                                [ 44%]
tests/plugins/test_decorators.py::test_process PASSED                              [ 45%]
tests/plugins/test_decorators.py::test_listen_to PASSED                            [ 46%]
tests/plugins/test_decorators.py::test_respond_to PASSED                           [ 47%]
tests/plugins/test_decorators.py::test_command PASSED                              [ 48%]
tests/plugins/test_decorators.py::test_command_no_slash PASSED                     [ 49%]
tests/plugins/test_decorators.py::test_command_generator PASSED                    [ 50%]
tests/plugins/test_decorators.py::test_schedule PASSED                             [ 51%]
tests/plugins/test_decorators.py::test_mulitple_decorators PASSED                  [ 52%]
tests/plugins/test_decorators.py::test_on PASSED                                   [ 53%]
tests/plugins/test_decorators.py::test_action PASSED                               [ 54%]
tests/plugins/test_decorators.py::test_action_regex PASSED                         [ 55%]
tests/plugins/test_decorators.py::test_action_no_action_or_block PASSED            [ 56%]
tests/plugins/test_decorators.py::test_modal PASSED                                [ 57%]
tests/plugins/test_decorators.py::test_modal_regex PASSED                          [ 58%]
tests/plugins/test_decorators.py::test_modal_generator PASSED                      [ 59%]
tests/plugins/test_decorators.py::test_modal_closed PASSED                         [ 60%]
tests/plugins/test_decorators.py::test_modal_closed_regex PASSED                   [ 61%]
tests/plugins/test_decorators.py::test_modal_closed_generator PASSED               [ 62%]
tests/plugins/test_decorators.py::test_required_settings_list PASSED               [ 63%]
tests/plugins/test_decorators.py::test_required_settings_str PASSED                [ 64%]
tests/plugins/test_decorators.py::test_required_settings_multiple PASSED           [ 65%]
tests/plugins/test_decorators.py::test_required_settings_for_class PASSED          [ 66%]
tests/storage/backends/test_memory_storage.py::test_store_retrieve_values PASSED   [ 67%]
tests/storage/backends/test_memory_storage.py::test_delete_values PASSED           [ 68%]
tests/storage/backends/test_memory_storage.py::test_expire_values PASSED           [ 69%]
tests/storage/backends/test_memory_storage.py::test_inclusion PASSED               [ 70%]
tests/storage/backends/test_redis_storage.py::test_set PASSED                      [ 71%]
tests/storage/backends/test_redis_storage.py::test_get PASSED                      [ 72%]
tests/storage/backends/test_redis_storage.py::test_has PASSED                      [ 73%]
tests/storage/backends/test_redis_storage.py::test_delete PASSED                   [ 74%]
tests/storage/backends/test_redis_storage.py::test_size PASSED                     [ 75%]
tests/storage/backends/test_sqlite_storage.py::test_set_and_get PASSED             [ 76%]
tests/storage/backends/test_sqlite_storage.py::test_has PASSED                     [ 77%]
tests/storage/backends/test_sqlite_storage.py::test_delete PASSED                  [ 78%]
tests/storage/backends/test_sqlite_storage.py::test_expire_values PASSED           [ 79%]
tests/storage/backends/test_sqlite_storage.py::test_size SKIPPED (DBSTAT is no...) [ 80%]
tests/storage/test_plugin_storage.py::test_namespacing PASSED                      [ 81%]
tests/storage/test_plugin_storage.py::test_inclusion PASSED                        [ 82%]
tests/storage/test_plugin_storage.py::test_retrieve PASSED                         [ 83%]
tests/storage/test_plugin_storage.py::test_shared PASSED                           [ 84%]
tests/storage/test_plugin_storage.py::test_delete PASSED                           [ 85%]
tests/test_import_settings.py::test_normal_import_settings PASSED                  [ 86%]
tests/test_import_settings.py::test_import_settings_non_existing_module PASSED     [ 87%]
tests/test_import_settings.py::test_env_import_settings PASSED                     [ 88%]
tests/test_plugin_registration.py::test_load_and_register_plugins PASSED           [ 89%]
tests/test_plugin_registration.py::test_plugin_storage_fq_plugin_name PASSED       [ 90%]
tests/test_plugin_registration.py::test_plugin_init PASSED                         [ 91%]
tests/test_plugin_registration.py::test_required_settings PASSED                   [ 92%]
tests/test_setup.py::test_setup PASSED                                             [ 93%]
tests/utils/test_datetime.py::test_calculate_epoch PASSED                          [ 94%]
tests/utils/test_import_string.py::test_import_all_classes PASSED                  [ 95%]
tests/utils/test_import_string.py::test_import_specific_class PASSED               [ 96%]
tests/utils/test_import_string.py::test_import_non_existing_module PASSED          [ 97%]
tests/utils/test_import_string.py::test_import_non_existing_class PASSED           [ 98%]
tests/utils/test_utils.py::test_CaseInsensitiveDict PASSED                         [ 99%]
tests/utils/test_utils.py::test_size_fmt PASSED                                    [100%]

======================================== FAILURES ========================================
__________________________ test_block_action_button_enterprise ___________________________

    def test_block_action_button_enterprise():
>       validated_button_enterprise_payload = InteractivePayload.validate_python(button_enterprise_payload)

tests/models/test_block_actions.py:40: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = TypeAdapter(Annotated[Union[BlockActionsPayload, ViewSubmissionPayload, ViewClosedPayload], FieldInfo(annotation=NoneType, required=True, discriminator='type')])
object = {'actions': [{'action_id': 'sushi', 'action_ts': '1716206811.107343', 'block_id': 'q3Yif', 'text': {'emoji': True, 'te...tainer': {'channel_id': 'CQEUMSV7D', 'is_ephemeral': False, 'message_ts': '1716206801.973899', 'type': 'message'}, ...}

    def validate_python(
        self,
        object: Any,
        /,
        *,
        strict: bool | None = None,
        from_attributes: bool | None = None,
        context: dict[str, Any] | None = None,
        experimental_allow_partial: bool | Literal['off', 'on', 'trailing-strings'] = False,
    ) -> T:
        """Validate a Python object against the model.
    
        Args:
            object: The Python object to validate against the model.
            strict: Whether to strictly check types.
            from_attributes: Whether to extract data from object attributes.
            context: Additional context to pass to the validator.
            experimental_allow_partial: **Experimental** whether to enable
                [partial validation](../concepts/experimental.md#partial-validation), e.g. to process streams.
                * False / 'off': Default behavior, no partial validation.
                * True / 'on': Enable partial validation.
                * 'trailing-strings': Enable partial validation and allow trailing strings in the input.
    
        !!! note
            When using `TypeAdapter` with a Pydantic `dataclass`, the use of the `from_attributes`
            argument is not supported.
    
        Returns:
            The validated object.
        """
>       return self.validator.validate_python(
            object,
            strict=strict,
            from_attributes=from_attributes,
            context=context,
            allow_partial=experimental_allow_partial,
        )
E       pydantic_core._pydantic_core.ValidationError: 1 validation error for tagged-union[function-after[validate_view_or_message(), BlockActionsPayload],ViewSubmissionPayload,ViewClosedPayload]
E       block_actions.enterprise
E         Input should be a valid string [type=string_type, input_value={'id': 'E039QKQ6G1E', 'name': 'DandyDev'}, input_type=dict]
E           For further information visit https://errors.pydantic.dev/2.10/v/string_type

.nox/test-3-12/lib/python3.12/site-packages/pydantic/type_adapter.py:412: ValidationError
--------- generated xml file: /Users/zotavka/Developer/slack-machine/pytest.xml ----------

---------- coverage: platform darwin, python 3.12.2-final-0 ----------
Name                                          Stmts   Miss  Cover   Missing
---------------------------------------------------------------------------
src/machine/__init__.py                           2      0   100%
src/machine/clients/__init__.py                   0      0   100%
src/machine/clients/slack.py                    212     83    61%   56, 91, 93, 103-125, 135-143, 155-164, 169-177, 226-231, 234-237, 241, 245, 249, 253, 262-270, 275-277, 282-283, 286-287, 290-291, 294-296, 299-301, 304-307, 312-313, 316-317, 320-321, 324, 327, 337, 344-345
src/machine/core.py                             220     47    79%   74, 80-81, 83-84, 103, 137-138, 148-151, 166, 195, 260, 313, 366-373, 384-415, 418-419
src/machine/handlers/__init__.py                  5      0   100%
src/machine/handlers/command_handler.py          41      2    95%   33-39
src/machine/handlers/event_handler.py            21      0   100%
src/machine/handlers/interactive_handler.py      92      6    93%   70-76, 95-101, 134-140
src/machine/handlers/logging.py                  12      0   100%
src/machine/handlers/message_handler.py          85     10    88%   28-49, 139, 150
src/machine/models/__init__.py                    2      0   100%
src/machine/models/channel.py                    33      0   100%
src/machine/models/core.py                       63      1    98%   79
src/machine/models/interactive.py               263      5    98%   339, 406, 409, 411, 413
src/machine/models/user.py                       46      0   100%
src/machine/plugins/__init__.py                   2      0   100%
src/machine/plugins/admin_utils.py               20     11    45%   15-20, 24-30
src/machine/plugins/base.py                      86     25    71%   127-132, 143, 154, 170, 215, 252, 298, 329, 350, 383, 411, 429, 441, 455, 469, 484, 500, 517, 541, 564
src/machine/plugins/block_action.py              51     14    73%   54, 63-65, 74, 83, 100, 145-152, 190, 213
src/machine/plugins/command.py                   43      9    79%   42, 51, 60-61, 92, 109, 143-145, 168
src/machine/plugins/decorators.py               128     28    78%   336-360, 379-403
src/machine/plugins/message.py                   69     29    58%   48, 57-58, 78, 87, 96, 140-142, 177, 228-232, 259-265, 296, 321, 336, 339-342, 352, 355-361, 364
src/machine/plugins/metadata.py                  34      0   100%
src/machine/plugins/modals.py                    45     10    78%   38, 47, 64, 87, 110, 133, 164, 189, 198, 228
src/machine/settings.py                          21      0   100%
src/machine/storage/__init__.py                  36      4    89%   63, 101, 110-111
src/machine/storage/backends/__init__.py          0      0   100%
src/machine/storage/backends/base.py             28      6    79%   42, 54, 62, 74, 83, 88
src/machine/storage/backends/dynamodb.py         88     88     0%   1-185
src/machine/storage/backends/memory.py           35      4    89%   21, 39-40, 51
src/machine/storage/backends/redis.py            28      1    96%   41
src/machine/storage/backends/sqlite.py           49      6    88%   76, 79-83
src/machine/utils/__init__.py                     6      1    83%   6
src/machine/utils/collections.py                 36      8    78%   57, 63, 67, 70-75, 79
src/machine/utils/datetime.py                     6      0   100%
src/machine/utils/logging.py                     27      3    89%   49, 74-75
src/machine/utils/module_loading.py              14      0   100%
src/machine/utils/redis.py                        8      0   100%
---------------------------------------------------------------------------
TOTAL                                          1957    401    80%
Coverage XML written to file coverage.xml

================================ short test summary info =================================
FAILED tests/models/test_block_actions.py::test_block_action_button_enterprise - pydantic_core._pydantic_core.ValidationError: 1 validation error for tagged-union[fun...
======================== 1 failed, 99 passed, 1 skipped in 4.72s =========================
nox > Command pytest  failed with exit code 1
nox > Session test-3.12 failed.
```

### Passing with Fixes
Then, I implemented my fixes for the models and re-ran the tests.

```
-> uvx nox -s test -p 3.12
nox > Running session test-3.12
nox > Creating virtual environment (uv) using python3.12 in .nox/test-3-12
nox > /Users/zotavka/.local/share/mise/installs/uv/0.8.11/uv-aarch64-apple-darwin/uv sync --python=3.12 --group=dev
Resolved 116 packages in 6ms
Installed 83 packages in 144ms
 + aioboto3==15.0.0
 + aiobotocore==2.23.0
 + aiofiles==24.1.0
 + aiohappyeyeballs==2.4.3
 + aiohttp==3.11.7
 + aioitertools==0.12.0
 + aiosignal==1.3.1
 + aiosqlite==0.21.0
 + annotated-types==0.7.0
 + anyio==4.6.2.post1
 + apscheduler==3.10.4
 + argcomplete==3.5.1
 + attrs==24.2.0
 + boto3==1.38.27
 + botocore==1.38.27
 + botocore-stubs==1.35.68
 + certifi==2024.8.30
 + cffi==1.17.1
 + cfgv==3.4.0
 + colorlog==6.9.0
 + coverage==7.6.7
 + cryptography==43.0.3
 + dill==0.3.9
 + distlib==0.3.9
 + filelock==3.16.1
 + frozenlist==1.5.0
 + h11==0.14.0
 + httpcore==1.0.7
 + httpx==0.28.0
 + identify==2.6.2
 + idna==3.10
 + iniconfig==2.0.0
 + jmespath==1.0.1
 + mock==5.1.0
 + multidict==6.1.0
 + mypy==1.14.0
 + mypy-extensions==1.0.0
 + nodeenv==1.9.1
 + nox==2024.10.9
 + packaging==24.2
 + platformdirs==4.3.6
 + pluggy==1.5.0
 + pre-commit==4.0.1
 + propcache==0.2.0
 + pycparser==2.22
 + pydantic==2.10.1
 + pydantic-core==2.27.1
 + pyee==13.0.0
 + pytest==8.3.3
 + pytest-asyncio==1.1.0
 + pytest-cov==6.0.0
 + pytest-mock==3.14.0
 + python-dateutil==2.9.0.post0
 + pytz==2024.2
 + pyyaml==6.0.2
 + redis==6.4.0
 + ruff==0.12.0
 + s3transfer==0.13.0
 + six==1.16.0
 + slack-machine==0.40.0 (from file:///Users/zotavka/Developer/slack-machine)
 + slack-sdk==3.33.4
 + sniffio==1.3.1
 + structlog==25.4.0
 + types-aiobotocore==2.15.2.post1
 + types-aiobotocore-cloudformation==2.15.2
 + types-aiobotocore-dynamodb==2.15.2
 + types-aiobotocore-ec2==2.15.2
 + types-aiobotocore-lambda==2.15.2
 + types-aiobotocore-rds==2.15.2
 + types-aiobotocore-s3==2.15.2
 + types-aiobotocore-sqs==2.15.2
 + types-awscrt==0.23.0
 + types-cffi==1.16.0.20240331
 + types-pyopenssl==24.1.0.20240722
 + types-redis==4.6.0.20241004
 + types-setuptools==75.5.0.20241122
 + typing-extensions==4.12.2
 + tzdata==2025.2
 + tzlocal==5.2
 + urllib3==1.26.20
 + virtualenv==20.27.1
 + wrapt==1.17.0
 + yarl==1.18.0
nox > pytest 
================================== test session starts ===================================
platform darwin -- Python 3.12.2, pytest-8.3.3, pluggy-1.5.0 -- /Users/zotavka/Developer/slack-machine/.nox/test-3-12/bin/python3
cachedir: .pytest_cache
rootdir: /Users/zotavka/Developer/slack-machine
configfile: pyproject.toml
plugins: cov-6.0.0, asyncio-1.1.0, mock-3.14.0, anyio-4.6.2.post1
asyncio: mode=Mode.STRICT, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
collected 101 items                                                                      

tests/clients/test_slack_client.py::test_id_for_user PASSED                        [  0%]
tests/clients/test_slack_client.py::test_id_for_channel PASSED                     [  1%]
tests/clients/test_slack_client.py::test_register_handler PASSED                   [  2%]
tests/clients/test_slack_client.py::test_process_users_channels PASSED             [  3%]
tests/clients/test_slack_client.py::test_process_users_channels_team_join PASSED   [  4%]
tests/clients/test_slack_client.py::test_process_users_channels_team_join_no_email PASSED [  5%]
tests/clients/test_slack_client.py::test_process_users_channels_user_change PASSED [  6%]
tests/clients/test_slack_client.py::test_process_users_channels_channel_created PASSED [  7%]
tests/clients/test_slack_client.py::test_process_users_channels_channel_deleted PASSED [  8%]
tests/clients/test_slack_client.py::test_process_users_channels_channel_rename PASSED [  9%]
tests/clients/test_slack_client.py::test_process_users_channels_channel_archive PASSED [ 10%]
tests/clients/test_slack_client.py::test_get_user_by_id PASSED                     [ 11%]
tests/clients/test_slack_client.py::test_get_user_by_email PASSED                  [ 12%]
tests/handlers/test_command_handler.py::test_create_slash_command_handler PASSED   [ 13%]
tests/handlers/test_command_handler.py::test_create_slash_command_handler_generator PASSED [ 14%]
tests/handlers/test_event_handler.py::test_create_generic_event_handler PASSED     [ 15%]
tests/handlers/test_interactive_handler.py::test_matches PASSED                    [ 16%]
tests/handlers/test_interactive_handler.py::test_create_interactive_handler_for_block_actions PASSED [ 17%]
tests/handlers/test_interactive_handler.py::test_create_interactive_handler_for_view_submission PASSED [ 18%]
tests/handlers/test_interactive_handler.py::test_create_interactive_handler_for_view_submission_generator PASSED [ 19%]
tests/handlers/test_interactive_handler.py::test_create_interactive_handler_for_view_closed PASSED [ 20%]
tests/handlers/test_logging.py::test_request_logger_handler PASSED                 [ 21%]
tests/handlers/test_message_handler.py::test_generate_message_matcher PASSED       [ 22%]
tests/handlers/test_message_handler.py::test_check_bot_mention PASSED              [ 23%]
tests/handlers/test_message_handler.py::test_handle_message_listen_to PASSED       [ 24%]
tests/handlers/test_message_handler.py::test_handle_message_respond_to PASSED      [ 25%]
tests/handlers/test_message_handler.py::test_handle_message_changed PASSED         [ 26%]
tests/models/test_block_actions.py::test_block_action_radio_button PASSED          [ 27%]
tests/models/test_block_actions.py::test_block_action_button PASSED                [ 28%]
tests/models/test_block_actions.py::test_block_action_button_enterprise PASSED     [ 29%]
tests/models/test_block_actions.py::test_block_action_checkboxes PASSED            [ 30%]
tests/models/test_block_actions.py::test_block_action_datepicker PASSED            [ 31%]
tests/models/test_block_actions.py::test_block_action_static_select PASSED         [ 32%]
tests/models/test_block_actions.py::test_block_action_conversations_select PASSED  [ 33%]
tests/models/test_block_actions.py::test_block_action_multi_static_select PASSED   [ 34%]
tests/models/test_block_actions.py::test_block_action_multi_channels_select PASSED [ 35%]
tests/models/test_block_actions.py::test_block_action_timepicker PASSED            [ 36%]
tests/models/test_block_actions.py::test_block_action_url_input PASSED             [ 37%]
tests/models/test_block_actions.py::test_block_action_overflow PASSED              [ 38%]
tests/models/test_block_actions.py::test_block_action_in_modal PASSED              [ 39%]
tests/models/test_channel.py::test_identifier_without_name PASSED                  [ 40%]
tests/models/test_channel.py::test_identifier_with_name PASSED                     [ 41%]
tests/models/test_user.py::test_fmt_mention PASSED                                 [ 42%]
tests/models/test_views.py::test_view_submission PASSED                            [ 43%]
tests/models/test_views.py::test_view_closed PASSED                                [ 44%]
tests/plugins/test_decorators.py::test_process PASSED                              [ 45%]
tests/plugins/test_decorators.py::test_listen_to PASSED                            [ 46%]
tests/plugins/test_decorators.py::test_respond_to PASSED                           [ 47%]
tests/plugins/test_decorators.py::test_command PASSED                              [ 48%]
tests/plugins/test_decorators.py::test_command_no_slash PASSED                     [ 49%]
tests/plugins/test_decorators.py::test_command_generator PASSED                    [ 50%]
tests/plugins/test_decorators.py::test_schedule PASSED                             [ 51%]
tests/plugins/test_decorators.py::test_mulitple_decorators PASSED                  [ 52%]
tests/plugins/test_decorators.py::test_on PASSED                                   [ 53%]
tests/plugins/test_decorators.py::test_action PASSED                               [ 54%]
tests/plugins/test_decorators.py::test_action_regex PASSED                         [ 55%]
tests/plugins/test_decorators.py::test_action_no_action_or_block PASSED            [ 56%]
tests/plugins/test_decorators.py::test_modal PASSED                                [ 57%]
tests/plugins/test_decorators.py::test_modal_regex PASSED                          [ 58%]
tests/plugins/test_decorators.py::test_modal_generator PASSED                      [ 59%]
tests/plugins/test_decorators.py::test_modal_closed PASSED                         [ 60%]
tests/plugins/test_decorators.py::test_modal_closed_regex PASSED                   [ 61%]
tests/plugins/test_decorators.py::test_modal_closed_generator PASSED               [ 62%]
tests/plugins/test_decorators.py::test_required_settings_list PASSED               [ 63%]
tests/plugins/test_decorators.py::test_required_settings_str PASSED                [ 64%]
tests/plugins/test_decorators.py::test_required_settings_multiple PASSED           [ 65%]
tests/plugins/test_decorators.py::test_required_settings_for_class PASSED          [ 66%]
tests/storage/backends/test_memory_storage.py::test_store_retrieve_values PASSED   [ 67%]
tests/storage/backends/test_memory_storage.py::test_delete_values PASSED           [ 68%]
tests/storage/backends/test_memory_storage.py::test_expire_values PASSED           [ 69%]
tests/storage/backends/test_memory_storage.py::test_inclusion PASSED               [ 70%]
tests/storage/backends/test_redis_storage.py::test_set PASSED                      [ 71%]
tests/storage/backends/test_redis_storage.py::test_get PASSED                      [ 72%]
tests/storage/backends/test_redis_storage.py::test_has PASSED                      [ 73%]
tests/storage/backends/test_redis_storage.py::test_delete PASSED                   [ 74%]
tests/storage/backends/test_redis_storage.py::test_size PASSED                     [ 75%]
tests/storage/backends/test_sqlite_storage.py::test_set_and_get PASSED             [ 76%]
tests/storage/backends/test_sqlite_storage.py::test_has PASSED                     [ 77%]
tests/storage/backends/test_sqlite_storage.py::test_delete PASSED                  [ 78%]
tests/storage/backends/test_sqlite_storage.py::test_expire_values PASSED           [ 79%]
tests/storage/backends/test_sqlite_storage.py::test_size SKIPPED (DBSTAT is no...) [ 80%]
tests/storage/test_plugin_storage.py::test_namespacing PASSED                      [ 81%]
tests/storage/test_plugin_storage.py::test_inclusion PASSED                        [ 82%]
tests/storage/test_plugin_storage.py::test_retrieve PASSED                         [ 83%]
tests/storage/test_plugin_storage.py::test_shared PASSED                           [ 84%]
tests/storage/test_plugin_storage.py::test_delete PASSED                           [ 85%]
tests/test_import_settings.py::test_normal_import_settings PASSED                  [ 86%]
tests/test_import_settings.py::test_import_settings_non_existing_module PASSED     [ 87%]
tests/test_import_settings.py::test_env_import_settings PASSED                     [ 88%]
tests/test_plugin_registration.py::test_load_and_register_plugins PASSED           [ 89%]
tests/test_plugin_registration.py::test_plugin_storage_fq_plugin_name PASSED       [ 90%]
tests/test_plugin_registration.py::test_plugin_init PASSED                         [ 91%]
tests/test_plugin_registration.py::test_required_settings PASSED                   [ 92%]
tests/test_setup.py::test_setup PASSED                                             [ 93%]
tests/utils/test_datetime.py::test_calculate_epoch PASSED                          [ 94%]
tests/utils/test_import_string.py::test_import_all_classes PASSED                  [ 95%]
tests/utils/test_import_string.py::test_import_specific_class PASSED               [ 96%]
tests/utils/test_import_string.py::test_import_non_existing_module PASSED          [ 97%]
tests/utils/test_import_string.py::test_import_non_existing_class PASSED           [ 98%]
tests/utils/test_utils.py::test_CaseInsensitiveDict PASSED                         [ 99%]
tests/utils/test_utils.py::test_size_fmt PASSED                                    [100%]

--------- generated xml file: /Users/zotavka/Developer/slack-machine/pytest.xml ----------

---------- coverage: platform darwin, python 3.12.2-final-0 ----------
Name                                          Stmts   Miss  Cover   Missing
---------------------------------------------------------------------------
src/machine/__init__.py                           2      0   100%
src/machine/clients/__init__.py                   0      0   100%
src/machine/clients/slack.py                    212     83    61%   56, 91, 93, 103-125, 135-143, 155-164, 169-177, 226-231, 234-237, 241, 245, 249, 253, 262-270, 275-277, 282-283, 286-287, 290-291, 294-296, 299-301, 304-307, 312-313, 316-317, 320-321, 324, 327, 337, 344-345
src/machine/core.py                             220     47    79%   74, 80-81, 83-84, 103, 137-138, 148-151, 166, 195, 260, 313, 366-373, 384-415, 418-419
src/machine/handlers/__init__.py                  5      0   100%
src/machine/handlers/command_handler.py          41      2    95%   33-39
src/machine/handlers/event_handler.py            21      0   100%
src/machine/handlers/interactive_handler.py      92      6    93%   70-76, 95-101, 134-140
src/machine/handlers/logging.py                  12      0   100%
src/machine/handlers/message_handler.py          85     10    88%   28-49, 139, 150
src/machine/models/__init__.py                    2      0   100%
src/machine/models/channel.py                    33      0   100%
src/machine/models/core.py                       63      1    98%   79
src/machine/models/interactive.py               263      5    98%   339, 406, 409, 411, 413
src/machine/models/user.py                       46      0   100%
src/machine/plugins/__init__.py                   2      0   100%
src/machine/plugins/admin_utils.py               20     11    45%   15-20, 24-30
src/machine/plugins/base.py                      86     25    71%   127-132, 143, 154, 170, 215, 252, 298, 329, 350, 383, 411, 429, 441, 455, 469, 484, 500, 517, 541, 564
src/machine/plugins/block_action.py              51     14    73%   54, 63-65, 74, 83, 100, 145-152, 190, 213
src/machine/plugins/command.py                   43      9    79%   42, 51, 60-61, 92, 109, 143-145, 168
src/machine/plugins/decorators.py               128     28    78%   336-360, 379-403
src/machine/plugins/message.py                   69     29    58%   48, 57-58, 78, 87, 96, 140-142, 177, 228-232, 259-265, 296, 321, 336, 339-342, 352, 355-361, 364
src/machine/plugins/metadata.py                  34      0   100%
src/machine/plugins/modals.py                    45     10    78%   38, 47, 64, 87, 110, 133, 164, 189, 198, 228
src/machine/settings.py                          21      0   100%
src/machine/storage/__init__.py                  36      4    89%   63, 101, 110-111
src/machine/storage/backends/__init__.py          0      0   100%
src/machine/storage/backends/base.py             28      6    79%   42, 54, 62, 74, 83, 88
src/machine/storage/backends/dynamodb.py         88     88     0%   1-185
src/machine/storage/backends/memory.py           35      4    89%   21, 39-40, 51
src/machine/storage/backends/redis.py            28      1    96%   41
src/machine/storage/backends/sqlite.py           49      6    88%   76, 79-83
src/machine/utils/__init__.py                     6      1    83%   6
src/machine/utils/collections.py                 36      8    78%   57, 63, 67, 70-75, 79
src/machine/utils/datetime.py                     6      0   100%
src/machine/utils/logging.py                     27      3    89%   49, 74-75
src/machine/utils/module_loading.py              14      0   100%
src/machine/utils/redis.py                        8      0   100%
---------------------------------------------------------------------------
TOTAL                                          1957    401    80%
Coverage XML written to file coverage.xml

============================= 100 passed, 1 skipped in 4.61s =============================
nox > Session test-3.12 was successful.
```